### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,9 +4,9 @@ module(
 )
 
 bazel_dep(name = "rules_foreign_cc", version = "0.15.1")
-bazel_dep(name = "rules_cc", version = "0.2.8")
+bazel_dep(name = "rules_cc", version = "0.2.19")
 
-bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.0")
+bazel_dep(name = "hermetic_cc_toolchain", version = "4.1.0")
 
 toolchains = use_extension("@hermetic_cc_toolchain//toolchain:ext.bzl", "toolchains")
 use_repo(toolchains, "zig_sdk")


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* rules_cc: 0.2.8 -> 0.2.19
* hermetic_cc_toolchain: 3.1.0 -> 4.1.0