### PR TITLE
fix: do not release when nothing has changed since the last release

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -6,7 +6,43 @@ on:
   workflow_dispatch:
 
 jobs:
+  # The scheduled run used to bump a version whether or not anything had
+  # landed, so the same tree was released again and again (see the tags that
+  # share one commit). This job asks the only question that matters -- did
+  # anything get committed since the last release? -- and every job below
+  # hangs off the answer.
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.changes.outputs.changed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history and tags: `git describe` needs both, and the default
+          # shallow checkout has neither.
+          fetch-depth: 0
+      - name: Look for commits since the last release
+        id: changes
+        run: |
+          set -o errexit -o nounset -o pipefail
+          latest="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          if [ -z "${latest}" ]; then
+            echo "No tag yet; releasing."
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if [ "$(git rev-list -n 1 "${latest}")" = "$(git rev-parse HEAD)" ]; then
+            echo "HEAD is already released as ${latest}. Nothing to release."
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "$(git rev-list --count "${latest}"..HEAD) commit(s) since ${latest}; releasing."
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+          fi
+
   tag:
+    needs: check
+    if: ${{ needs.check.outputs.changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Setup bazel


### PR DESCRIPTION
The scheduled run releases the same tree again and again: **46 of 49 tags in this repository point at a commit some other tag already names** (counted 2026-08-21). Each empty bump also makes a GitHub release, and where a publish job exists, opens a registry PR.

The cause is `mathieudutour/github-tag-action`: its `default_bump` input defaults to `patch`, so it tags on every run even with no new commits.

This PR adds a `check` job that compares `HEAD` against the commit behind the most recent tag; tagging runs only when they differ, and the downstream jobs skip with it. Same fix as [bazel-go-basic#42](https://github.com/filmil/bazel-go-basic/pull/42): it keys on whether the tree moved rather than on commit-message style, so it cannot suppress a real release in a repository whose commits do not follow conventional-commit prefixes.

Part of a sweep over all repos with this workflow pattern; 24 repos get this same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQtu8bDymbseq6K7SrnxiP